### PR TITLE
11-get-api-articles-sorting-queries

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -217,3 +217,49 @@ describe("GET /api/users", () => {
       });
   });
 });
+
+describe("/api/articles?sort_by=created_at", () => {
+  test("responds with 200 and an array of objects which have required properties and sorted by treasure_name", () => {
+    return request(app)
+      .get("/api/articles?sort_by=created_at")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles.length).toEqual(13);
+        body.articles.forEach((element) => {
+          expect(element).toMatchObject({
+            article_id: expect.any(Number),
+            title: expect.any(String),
+            topic: expect.any(String),
+            author: expect.any(String),
+            body: expect.any(String),
+            created_at: expect.any(String),
+            votes: expect.any(Number),
+            article_img_url: expect.any(String),
+          });
+        });
+      });
+  });
+});
+
+describe("/api/articles?sort_by=created_at&order=desc", () => {
+  test("responds with 200 and an array of objects which have required properties and sorted by treasure_name", () => {
+    return request(app)
+      .get("/api/articles?sort_by=created_at&order=desc")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles.length).toEqual(13);
+        body.articles.forEach((element) => {
+          expect(element).toMatchObject({
+            article_id: expect.any(Number),
+            title: expect.any(String),
+            topic: expect.any(String),
+            author: expect.any(String),
+            body: expect.any(String),
+            created_at: expect.any(String),
+            votes: expect.any(Number),
+            article_img_url: expect.any(String),
+          });
+        });
+      });
+  });
+});

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -39,7 +39,8 @@ exports.getArticleFromArticleId = (req, res, next) => {
 };
 
 exports.getArticles = (req, res, next) => {
-  fetchArticles()
+  const queries = req.query;
+  fetchArticles(queries)
     .then((result) => {
       res.send({ articles: result });
     })

--- a/models/models.js
+++ b/models/models.js
@@ -29,9 +29,32 @@ exports.fetchArticleFromArticleId = (id) => {
   });
 };
 
-exports.fetchArticles = () => {
+exports.fetchArticles = (queries) => {
+  const sort_by = queries.sort_by;
+  const order = queries.order;
   let SQLString = "SELECT * FROM articles";
-  return db.query(SQLString).then((result) => {
+  args = [];
+
+  const greenList = [
+    "title",
+    "topic",
+    "author",
+    "body",
+    "created_at",
+    "votes",
+    "article_img_url",
+  ];
+
+  if (greenList.includes(sort_by)) {
+    SQLString += ` ORDER BY $1`;
+    args.push(sort_by);
+
+    if (order === "desc" || order === "asc") {
+      SQLString += " " + order;
+    }
+  }
+
+  return db.query(SQLString, args).then((result) => {
     if (result.length === 0) {
       return Promise.reject();
     } else {


### PR DESCRIPTION
make endpoint GET /api/articles accept sorting queries, sord_by and order
complete with tests for returning objects length and types